### PR TITLE
docs: align MVP roadmap with implementation gates

### DIFF
--- a/.github/prompts/memory-driven-issue-execution.prompt.md
+++ b/.github/prompts/memory-driven-issue-execution.prompt.md
@@ -44,7 +44,9 @@ Workflow (execute in order):
 - If issues are found, fix them before proceeding.
 
 6. Finalize:
-- Create a draft pull request first with a concise summary, testing notes, and issue linkage.
+- Create a draft pull request first with a concise summary, testing notes, and **GitHub auto-closing issue linkage**.
+- The draft PR body must include an explicit closing keyword such as `Closes #123`, `Fixes #123`, or `Resolves owner/repo#123` for every implemented issue so GitHub can automatically close it when the PR merges. A plain reference to the issue is not sufficient.
+- After creating the draft PR, verify that the linked issue appears in the PR metadata or body exactly as an auto-closing reference. If the closing linkage is missing or only mentioned generically, edit the PR before proceeding.
 - Complete self-review and any follow-up fixes.
 - If the result is clean, commit with a clear message and transition the pull request to ready for review.
 - Request GitHub Copilot review on the PR.
@@ -59,7 +61,7 @@ Output format:
 - Validation: <commands + results>
 - Self-review findings: <none or list>
 - Commit: <hash + message>
-- PR: <link>
+- PR: <link + explicit closing reference used>
 - Copilot review: <requested/pending/result>
 - Memory summary: <what was stored, why, and which durable principle or synthesis was captured>
 
@@ -68,5 +70,7 @@ Rules:
 - Favor connective synthesis over raw task logging: link implementation memories back to reusable reasoning whenever possible.
 - Use sub-agents only when available and when the delegated work has a clear boundary and expected output.
 - Include a final handoff memory at the end of the run.
+- PR issue linkage is mandatory: when work maps to a GitHub issue, the PR body must contain explicit GitHub auto-closing syntax. Do not rely on generic mentions like `Issue #9` or non-closing references.
+- Do not mark the PR ready for review until the closing reference has been confirmed in the PR body or metadata.
 - Do not claim completion if tests fail or required checks are not run.
 - If blocked by permissions (push/PR/review), report the blocker and provide exact next commands/actions.

--- a/plans/inheritance-manor-gdd-deep-plans/08-mvp-roadmap.md
+++ b/plans/inheritance-manor-gdd-deep-plans/08-mvp-roadmap.md
@@ -28,32 +28,78 @@ Exit criteria:
 - authored snapshot boundaries are explicit,
 - the repository has an implementation-ready planning baseline.
 
-### Milestone 1: Snapshot Foundation
+Primary evidence:
+
+- `plans/inheritance-manor-gdd-deep-plans/*.md` form a coherent packet,
+- the roadmap does not expand MVP scope beyond prologue plus first night.
+
+Validation expectations:
+
+- cross-check the roadmap against the gap-analysis, systems, snapshot, and architecture docs,
+- confirm that no milestone assumes a locked client framework or post-MVP campaign content,
+- verify that authored-versus-runtime separation is named before any runtime milestone.
+
+### Milestone 1: Memory System Foundation
+
+Exit criteria:
+
+- the memory-system contract supports authored and runtime records without allowing one to overwrite the other,
+- deterministic authored IDs and canonical tag validation are enforced,
+- retrieval supports room, phase, NPC, and district-oriented queries,
+- snapshot import/export primitives and graph traversal exist for later content and runtime use.
+
+Primary evidence:
+
+- `src/yorkz/memory_system.py` implements the core record, search, traversal, and snapshot behavior,
+- `tests/test_memory_system.py` covers authored/runtime protection, search, traversal, and snapshot round-trips.
+
+Validation expectations:
+
+- run `pytest tests/test_memory_system.py` and keep the suite green,
+- confirm authored records cannot be replaced by runtime records,
+- confirm snapshot round-trips preserve authored records and expected connections.
+
+### Milestone 2: Content Pipeline And Snapshot Readiness
 
 Exit criteria:
 
 - deterministic ID strategy is implemented in authored content,
-- the initial snapshot schema exists,
-- the seed-memory pack covers the MVP rooms, rules, hooks, and NPCs,
-- import validation exists.
+- the authored snapshot schema exists as a canonical file contract,
+- the seed-memory pack covers the MVP rooms, rules, hooks, clues, and NPC anchors,
+- authored import validation rejects malformed or runtime-only content,
+- production snapshot loading is separated from draft authoring references.
 
-### Milestone 2: Memory-Driven Runtime Core
+Primary evidence:
+
+- `campaigns/inheritance-manor/prologue-snapshot.json` is the canonical authored seed pack,
+- `docs/initial drafts/draft-inheritance-manor-memories.json` is a planning mirror rather than the runtime import target,
+- content-pipeline code validates, loads, and exports authored snapshot content.
+
+Validation expectations:
+
+- verify the canonical seed pack contains the MVP categories required by the systems and snapshot docs,
+- validate snapshot loading and authored export behavior through targeted tests,
+- confirm runtime-only entries are rejected during authored import.
+
+### Milestone 3: Technical Architecture Contract
 
 Exit criteria:
 
-- the orchestrator can retrieve authored state by room, phase, and NPC,
-- runtime writes preserve authored baseline,
-- relationship and clue deltas persist across scenes,
-- recap inputs can be generated from stored state.
+- the three-layer split between client, AI Game Master, and memory server is explicit,
+- the player-facing client contract stays text-first and keyboard-operable without locking a framework,
+- the AI Game Master is defined as an orchestration layer over explicit memory state,
+- MCP integration rules are auditable through explicit retrieval order, write rules, and runtime lineage scope.
 
-### Milestone 3: Text-First Client MVP
+Primary evidence:
 
-Exit criteria:
+- `plans/inheritance-manor-gdd-deep-plans/06-technical-architecture.md` names the layer boundaries, runtime flow, and validation surfaces,
+- architecture decisions preserve authored/runtime separation and active-lineage filtering.
 
-- the client accepts keyboard input,
-- transcript scrollback works,
-- recap/help affordances exist,
-- day-night transitions are legible in presentation.
+Validation expectations:
+
+- confirm the architecture doc does not smuggle in prompt-only truth or hidden state,
+- confirm runtime scoping, auditability, and authored import constraints are spelled out,
+- confirm the repository remains documentation-first until milestone 1 and milestone 2 inputs are stable.
 
 ### Milestone 4: Playable Vertical Slice
 
@@ -65,7 +111,34 @@ Exit criteria:
 - first-night shift fires reliably,
 - Thomas functions as the emotional anchor,
 - outside-danger boundary is taught in fiction,
-- morning-after endpoint closes the slice cleanly.
+- morning-after endpoint closes the slice cleanly,
+- the integrated runtime preserves relationship, clue, and recap continuity across the slice.
+
+Primary evidence:
+
+- the runtime stack can execute a complete prologue-plus-first-night run,
+- recap and continuity outputs are drawn from stored state rather than hand-waved prompt context.
+
+Validation expectations:
+
+- complete a representative playable pass from inheritance notice through morning after,
+- confirm day/night transitions, relationship deltas, clue persistence, and recap outputs survive the slice,
+- confirm the integrated system still respects authored/runtime boundaries.
+
+## Milestone Sequencing
+
+| Milestone | Depends on | Current scope | Linked issue thread |
+| --- | --- | --- | --- |
+| 0. Planning Packet Complete | none | canonical planning baseline | planning packet |
+| 1. Memory System Foundation | Milestone 0 | storage, search, traversal, snapshot primitives | issue #9 |
+| 2. Content Pipeline And Snapshot Readiness | Milestone 1 | canonical seed pack, authored validation, import/export discipline | issue #10 |
+| 3. Technical Architecture Contract | Milestone 0, Milestone 1, Milestone 2 | layer boundaries, client contract, auditable MCP orchestration rules | issue #11 |
+| 4. Playable Vertical Slice | Milestone 1, Milestone 2, Milestone 3 | integrated prologue-plus-first-night runtime | future slice implementation |
+
+Documentation-first rule:
+
+- The repository should not treat milestone 4 as active implementation work until milestone 1, milestone 2, and milestone 3 have all cleared their validation gates.
+- Framework selection remains deferred until the technical-architecture contract and authored content inputs are stable enough to protect the runtime from churn.
 
 ## Backlog After MVP
 
@@ -87,13 +160,44 @@ Exit criteria:
 ## Review Order
 
 1. Confirm planning packet consistency.
-2. Confirm snapshot schema and seed-pack readiness.
-3. Confirm architecture contracts.
-4. Begin runtime implementation only after the above are stable.
+2. Confirm memory-system gates pass on the active base branch.
+3. Confirm snapshot schema, seed-pack readiness, and authored import validation.
+4. Confirm architecture contracts and documentation-first stop conditions.
+5. Begin vertical-slice runtime implementation only after the above are stable.
+
+## Milestone Gate Checks
+
+### Gate 0: Planning complete
+
+- `rg "MVP Roadmap|Documentation Before Runtime|authored|runtime" plans/inheritance-manor-gdd-deep-plans docs/GDD`
+- manual consistency review across docs 01 through 08.
+
+### Gate 1: Memory-system complete
+
+- `pytest tests/test_memory_system.py`
+- verify authored/runtime overwrite protection and snapshot round-trip behavior.
+
+### Gate 2: Content-pipeline complete
+
+- validate the canonical authored snapshot and confirm required MVP anchors exist,
+- run the snapshot-focused tests once the content-pipeline implementation lands on the active branch.
+
+### Gate 3: Architecture contract complete
+
+- confirm the architecture doc still defers framework choice,
+- confirm retrieval order, runtime lineage, and explicit write rules are spelled out.
+
+### Gate 4: Vertical-slice complete
+
+- execute an end-to-end playable pass,
+- verify recap continuity, relationship persistence, clue progression, and the inside-versus-outside safety rule.
 
 ## Verification Checklist
 
 - Milestones are ordered from planning to playable slice.
+- Milestone names and sequencing match the real implementation slices: memory system, content pipeline, architecture, then playable slice.
+- Gating criteria for each milestone are concrete enough to test or manually verify.
+- Validation expectations exist for every milestone.
 - The roadmap does not pretend later acts are part of the MVP.
 - Risks map to concrete mitigations.
 - The review order reinforces planning before runtime.

--- a/plans/inheritance-manor-gdd-deep-plans/08-mvp-roadmap.md
+++ b/plans/inheritance-manor-gdd-deep-plans/08-mvp-roadmap.md
@@ -71,9 +71,9 @@ Exit criteria:
 
 Primary evidence:
 
-- `campaigns/inheritance-manor/prologue-snapshot.json` is the canonical authored seed pack,
-- `docs/initial drafts/draft-inheritance-manor-memories.json` is a planning mirror rather than the runtime import target,
-- content-pipeline code validates, loads, and exports authored snapshot content.
+- `campaigns/inheritance-manor/prologue-snapshot.json` is the required canonical authored seed-pack path for Milestone 2 once the content pipeline lands,
+- `docs/initial drafts/draft-inheritance-manor-memories.json` remains a planning mirror rather than the runtime import target,
+- content-pipeline code provides validation, loading, and export support for authored snapshot content against that canonical artifact.
 
 Validation expectations:
 

--- a/plans/inheritance-manor-gdd-deep-plans/implementation.md
+++ b/plans/inheritance-manor-gdd-deep-plans/implementation.md
@@ -1125,32 +1125,78 @@ Exit criteria:
 - authored snapshot boundaries are explicit,
 - the repository has an implementation-ready planning baseline.
 
-### Milestone 1: Snapshot Foundation
+Primary evidence:
+
+- `plans/inheritance-manor-gdd-deep-plans/*.md` form a coherent packet,
+- the roadmap does not expand MVP scope beyond prologue plus first night.
+
+Validation expectations:
+
+- cross-check the roadmap against the gap-analysis, systems, snapshot, and architecture docs,
+- confirm that no milestone assumes a locked client framework or post-MVP campaign content,
+- verify that authored-versus-runtime separation is named before any runtime milestone.
+
+### Milestone 1: Memory System Foundation
+
+Exit criteria:
+
+- the memory-system contract supports authored and runtime records without allowing one to overwrite the other,
+- deterministic authored IDs and canonical tag validation are enforced,
+- retrieval supports room, phase, NPC, and district-oriented queries,
+- snapshot import/export primitives and graph traversal exist for later content and runtime use.
+
+Primary evidence:
+
+- `src/yorkz/memory_system.py` implements the core record, search, traversal, and snapshot behavior,
+- `tests/test_memory_system.py` covers authored/runtime protection, search, traversal, and snapshot round-trips.
+
+Validation expectations:
+
+- run `pytest tests/test_memory_system.py` and keep the suite green,
+- confirm authored records cannot be replaced by runtime records,
+- confirm snapshot round-trips preserve authored records and expected connections.
+
+### Milestone 2: Content Pipeline And Snapshot Readiness
 
 Exit criteria:
 
 - deterministic ID strategy is implemented in authored content,
-- the initial snapshot schema exists,
-- the seed-memory pack covers the MVP rooms, rules, hooks, and NPCs,
-- import validation exists.
+- the authored snapshot schema exists as a canonical file contract,
+- the seed-memory pack covers the MVP rooms, rules, hooks, clues, and NPC anchors,
+- authored import validation rejects malformed or runtime-only content,
+- production snapshot loading is separated from draft authoring references.
 
-### Milestone 2: Memory-Driven Runtime Core
+Primary evidence:
+
+- `campaigns/inheritance-manor/prologue-snapshot.json` is the required canonical authored seed-pack path for Milestone 2 once the content pipeline lands,
+- `docs/initial drafts/draft-inheritance-manor-memories.json` remains a planning mirror rather than the runtime import target,
+- content-pipeline code provides validation, loading, and export support for authored snapshot content against that canonical artifact.
+
+Validation expectations:
+
+- verify the canonical seed pack contains the MVP categories required by the systems and snapshot docs,
+- validate snapshot loading and authored export behavior through targeted tests,
+- confirm runtime-only entries are rejected during authored import.
+
+### Milestone 3: Technical Architecture Contract
 
 Exit criteria:
 
-- the orchestrator can retrieve authored state by room, phase, and NPC,
-- runtime writes preserve authored baseline,
-- relationship and clue deltas persist across scenes,
-- recap inputs can be generated from stored state.
+- the three-layer split between client, AI Game Master, and memory server is explicit,
+- the player-facing client contract stays text-first and keyboard-operable without locking a framework,
+- the AI Game Master is defined as an orchestration layer over explicit memory state,
+- MCP integration rules are auditable through explicit retrieval order, write rules, and runtime lineage scope.
 
-### Milestone 3: Text-First Client MVP
+Primary evidence:
 
-Exit criteria:
+- `plans/inheritance-manor-gdd-deep-plans/06-technical-architecture.md` names the layer boundaries, runtime flow, and validation surfaces,
+- architecture decisions preserve authored/runtime separation and active-lineage filtering.
 
-- the client accepts keyboard input,
-- transcript scrollback works,
-- recap/help affordances exist,
-- day-night transitions are legible in presentation.
+Validation expectations:
+
+- confirm the architecture doc does not smuggle in prompt-only truth or hidden state,
+- confirm runtime scoping, auditability, and authored import constraints are spelled out,
+- confirm the repository remains documentation-first until milestone 1 and milestone 2 inputs are stable.
 
 ### Milestone 4: Playable Vertical Slice
 
@@ -1162,7 +1208,34 @@ Exit criteria:
 - first-night shift fires reliably,
 - Thomas functions as the emotional anchor,
 - outside-danger boundary is taught in fiction,
-- morning-after endpoint closes the slice cleanly.
+- morning-after endpoint closes the slice cleanly,
+- the integrated runtime preserves relationship, clue, and recap continuity across the slice.
+
+Primary evidence:
+
+- the runtime stack can execute a complete prologue-plus-first-night run,
+- recap and continuity outputs are drawn from stored state rather than hand-waved prompt context.
+
+Validation expectations:
+
+- complete a representative playable pass from inheritance notice through morning after,
+- confirm day/night transitions, relationship deltas, clue persistence, and recap outputs survive the slice,
+- confirm the integrated system still respects authored/runtime boundaries.
+
+## Milestone Sequencing
+
+| Milestone | Depends on | Current scope | Linked issue thread |
+| --- | --- | --- | --- |
+| 0. Planning Packet Complete | none | canonical planning baseline | planning packet |
+| 1. Memory System Foundation | Milestone 0 | storage, search, traversal, snapshot primitives | issue #9 |
+| 2. Content Pipeline And Snapshot Readiness | Milestone 1 | canonical seed pack, authored validation, import/export discipline | issue #10 |
+| 3. Technical Architecture Contract | Milestone 0, Milestone 1, Milestone 2 | layer boundaries, client contract, auditable MCP orchestration rules | issue #11 |
+| 4. Playable Vertical Slice | Milestone 1, Milestone 2, Milestone 3 | integrated prologue-plus-first-night runtime | future slice implementation |
+
+Documentation-first rule:
+
+- The repository should not treat milestone 4 as active implementation work until milestone 1, milestone 2, and milestone 3 have all cleared their validation gates.
+- Framework selection remains deferred until the technical-architecture contract and authored content inputs are stable enough to protect the runtime from churn.
 
 ## Backlog After MVP
 
@@ -1184,13 +1257,44 @@ Exit criteria:
 ## Review Order
 
 1. Confirm planning packet consistency.
-2. Confirm snapshot schema and seed-pack readiness.
-3. Confirm architecture contracts.
-4. Begin runtime implementation only after the above are stable.
+2. Confirm memory-system gates pass on the active base branch.
+3. Confirm snapshot schema, seed-pack readiness, and authored import validation.
+4. Confirm architecture contracts and documentation-first stop conditions.
+5. Begin vertical-slice runtime implementation only after the above are stable.
+
+## Milestone Gate Checks
+
+### Gate 0: Planning complete
+
+- `rg "MVP Roadmap|Documentation Before Runtime|authored|runtime" plans/inheritance-manor-gdd-deep-plans docs/GDD`
+- manual consistency review across docs 01 through 08.
+
+### Gate 1: Memory-system complete
+
+- `pytest tests/test_memory_system.py`
+- verify authored/runtime overwrite protection and snapshot round-trip behavior.
+
+### Gate 2: Content-pipeline complete
+
+- validate the canonical authored snapshot and confirm required MVP anchors exist,
+- run the snapshot-focused tests once the content-pipeline implementation lands on the active branch.
+
+### Gate 3: Architecture contract complete
+
+- confirm the architecture doc still defers framework choice,
+- confirm retrieval order, runtime lineage, and explicit write rules are spelled out.
+
+### Gate 4: Vertical-slice complete
+
+- execute an end-to-end playable pass,
+- verify recap continuity, relationship persistence, clue progression, and the inside-versus-outside safety rule.
 
 ## Verification Checklist
 
 - Milestones are ordered from planning to playable slice.
+- Milestone names and sequencing match the real implementation slices: memory system, content pipeline, architecture, then playable slice.
+- Gating criteria for each milestone are concrete enough to test or manually verify.
+- Validation expectations exist for every milestone.
 - The roadmap does not pretend later acts are part of the MVP.
 - Risks map to concrete mitigations.
 - The review order reinforces planning before runtime.


### PR DESCRIPTION
## Summary
- realign the roadmap milestones to the repository's actual implementation slices
- add explicit milestone evidence, validation expectations, and gate checks
- make the documentation-first stop condition explicit before vertical-slice runtime work

## Validation
- git diff --check -- plans/inheritance-manor-gdd-deep-plans/08-mvp-roadmap.md
- python -m pytest tests/test_memory_system.py
- PowerShell Select-String checks for new roadmap milestone headings

Closes #12