### PR TITLE
feat: implement issue #11 technical architecture contract layer

### DIFF
--- a/plans/inheritance-manor-gdd-deep-plans/06-technical-architecture.md
+++ b/plans/inheritance-manor-gdd-deep-plans/06-technical-architecture.md
@@ -190,6 +190,16 @@ This keeps the architecture stable while the repository is still proving the cam
 - current phase and room context remain visible without hidden UI state,
 - a session can resume from recap-ready stored memory without ad hoc reconstruction.
 
+## Implementation Status Link (Issue #11)
+
+The Milestone 3 contract layer is implemented in code through:
+
+- `src/yorkz/turn_orchestration.py` for turn input/output contracts and the minimal orchestration loop,
+- lineage-scoped runtime retrieval policy enforcement and deterministic write-intent generation in the same module,
+- focused contract tests in `tests/test_turn_orchestration.py`.
+
+These artifacts operationalize the interface contracts and testing surfaces in this document while keeping framework choice deferred.
+
 ## Verification Checklist
 
 - The three-layer architecture is explicit.

--- a/src/yorkz/__init__.py
+++ b/src/yorkz/__init__.py
@@ -1,5 +1,7 @@
 """Yorkz runtime and tooling package."""
 
-__all__ = ["__version__"]
+from yorkz.turn_orchestration import TurnInput, TurnOrchestrator
+
+__all__ = ["__version__", "TurnInput", "TurnOrchestrator"]
 
 __version__ = "0.1.0"

--- a/src/yorkz/turn_orchestration.py
+++ b/src/yorkz/turn_orchestration.py
@@ -1,0 +1,311 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from yorkz.memory_system import MemoryRecord, MemorySystem
+
+
+WRITE_CATEGORIES = {
+    "decision",
+    "clue",
+    "relationship_delta",
+    "phase_transition",
+    "recap",
+    "loop_telemetry",
+}
+
+
+def _normalize_token(value: str) -> str:
+    cleaned = "".join(ch.lower() if ch.isalnum() else "_" for ch in value).strip("_")
+    while "__" in cleaned:
+        cleaned = cleaned.replace("__", "_")
+    return cleaned
+
+
+def _word_tokens(value: str) -> set[str]:
+    return {
+        token
+        for token in (_normalize_token(value).split("_"))
+        if token
+    }
+
+
+@dataclass(slots=True)
+class TurnInput:
+    session_id: str
+    project_id: str
+    lineage_id: str
+    player_command: str
+    phase_hint: str | None = None
+    location_hint: str | None = None
+    recap_requested: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.session_id.strip():
+            raise ValueError("session_id is required.")
+        if not self.project_id.strip():
+            raise ValueError("project_id is required.")
+        if not self.lineage_id.strip():
+            raise ValueError("lineage_id is required.")
+        if not self.player_command.strip():
+            raise ValueError("player_command is required.")
+
+
+@dataclass(slots=True)
+class WriteIntent:
+    category: str
+    record_id: str
+    district: str
+    content: str
+    tags: list[str]
+
+    def __post_init__(self) -> None:
+        if self.category not in WRITE_CATEGORIES:
+            raise ValueError(f"Unsupported write category '{self.category}'.")
+
+
+@dataclass(slots=True)
+class TurnOutput:
+    transcript_text: str
+    affordances: list[str]
+    current_phase_id: str
+    current_location_id: str
+    memory_write_summary: list[str]
+    recap_trigger: bool
+    write_intents: list[WriteIntent]
+    recap_inputs: list[str]
+    audit_trace: dict[str, Any] = field(default_factory=dict)
+
+
+class TurnOrchestrator:
+    """Framework-neutral turn orchestrator for the text-first runtime contract."""
+
+    def __init__(self, *, memory_store: MemorySystem, project_id: str) -> None:
+        self._memory_store = memory_store
+        self._project_id = project_id
+
+    def process_turn(self, turn_input: TurnInput) -> TurnOutput:
+        if turn_input.project_id != self._project_id:
+            raise ValueError(
+                f"Turn project_id '{turn_input.project_id}' does not match orchestrator project_id '{self._project_id}'."
+            )
+
+        authored_records, runtime_records = self._resolve_retrieval_context(
+            lineage_id=turn_input.lineage_id,
+        )
+        current_phase_id = self._resolve_phase_id(runtime_records, turn_input.phase_hint)
+        current_location_id = self._resolve_location_id(runtime_records, turn_input.location_hint)
+        recap_inputs = self._resolve_recap_inputs(runtime_records, turn_input.recap_requested)
+
+        turn_index = len(runtime_records) + 1
+        write_intents = self._build_write_intents(
+            turn_input=turn_input,
+            turn_index=turn_index,
+            current_phase_id=current_phase_id,
+            current_location_id=current_location_id,
+            runtime_records=runtime_records,
+        )
+        recap_trigger = turn_input.recap_requested or any(
+            intent.category == "recap" for intent in write_intents
+        )
+
+        summary = [
+            f"{intent.category}:{intent.record_id}"
+            for intent in write_intents
+        ]
+        transcript = self._compose_transcript(
+            turn_input.player_command,
+            current_phase_id,
+            current_location_id,
+            write_intents,
+            recap_trigger,
+        )
+
+        return TurnOutput(
+            transcript_text=transcript,
+            affordances=["inspect", "talk", "move", "wait", "recap"],
+            current_phase_id=current_phase_id,
+            current_location_id=current_location_id,
+            memory_write_summary=summary,
+            recap_trigger=recap_trigger,
+            write_intents=write_intents,
+            recap_inputs=recap_inputs,
+            audit_trace={
+                "authored_record_ids": sorted(record.record_id for record in authored_records),
+                "runtime_record_ids": sorted(record.record_id for record in runtime_records),
+                "lineage_id": turn_input.lineage_id,
+            },
+        )
+
+    def _resolve_retrieval_context(self, *, lineage_id: str) -> tuple[list[MemoryRecord], list[MemoryRecord]]:
+        authored_records = [
+            record
+            for record in self._memory_store.records.values()
+            if record.memory_type == "authored" and record.project_id == self._project_id
+        ]
+        runtime_records = [
+            record
+            for record in self._memory_store.records.values()
+            if (
+                record.memory_type == "runtime"
+                and record.project_id == self._project_id
+                and record.lineage_id == lineage_id
+            )
+        ]
+        return authored_records, runtime_records
+
+    def _resolve_phase_id(self, runtime_records: list[MemoryRecord], phase_hint: str | None) -> str:
+        for record in reversed(runtime_records):
+            phase_tag = next((tag for tag in record.tags if tag.startswith("phase:")), None)
+            if phase_tag:
+                return phase_tag.split(":", 1)[1]
+        if phase_hint:
+            return phase_hint
+        authored_phase_ids = sorted(
+            record.record_id
+            for record in self._memory_store.records.values()
+            if record.memory_type == "authored" and record.record_id.startswith("phase_")
+        )
+        if authored_phase_ids:
+            return authored_phase_ids[0]
+        return "phase_unknown"
+
+    def _resolve_location_id(self, runtime_records: list[MemoryRecord], location_hint: str | None) -> str:
+        for record in reversed(runtime_records):
+            location_tag = next((tag for tag in record.tags if tag.startswith("location:")), None)
+            if location_tag:
+                return location_tag.split(":", 1)[1]
+        if location_hint:
+            return location_hint
+        authored_location_ids = sorted(
+            record.record_id
+            for record in self._memory_store.records.values()
+            if record.memory_type == "authored" and record.record_id.startswith("loc_")
+        )
+        if authored_location_ids:
+            return authored_location_ids[0]
+        return "location_unknown"
+
+    def _resolve_recap_inputs(self, runtime_records: list[MemoryRecord], recap_requested: bool) -> list[str]:
+        if not recap_requested:
+            return []
+        important = []
+        for record in runtime_records:
+            if any(
+                tag.startswith("kind:")
+                and tag in {
+                    "kind:decision",
+                    "kind:clue",
+                    "kind:relationship_delta",
+                    "kind:phase_transition",
+                    "kind:recap",
+                }
+                for tag in record.tags
+            ):
+                important.append(record.record_id)
+        return important[-5:]
+
+    def _classify_categories(
+        self,
+        *,
+        player_command: str,
+        recap_requested: bool,
+        runtime_records: list[MemoryRecord],
+    ) -> list[str]:
+        command_tokens = _word_tokens(player_command)
+        categories: list[str] = []
+
+        if command_tokens.intersection({"look", "inspect", "search", "investigate"}):
+            categories.append("clue")
+        if command_tokens.intersection({"talk", "ask", "comfort", "threaten"}):
+            categories.append("relationship_delta")
+        if command_tokens.intersection({"move", "go", "enter", "leave", "take", "use"}):
+            categories.append("decision")
+        if command_tokens.intersection({"wait", "sleep", "night", "morning"}):
+            categories.append("phase_transition")
+
+        if recap_requested or "recap" in command_tokens:
+            categories.append("recap")
+
+        if self._is_repeated_command(player_command, runtime_records):
+            categories.append("loop_telemetry")
+
+        if not categories:
+            categories.append("decision")
+        return sorted(set(categories))
+
+    def _is_repeated_command(self, player_command: str, runtime_records: list[MemoryRecord]) -> bool:
+        normalized = player_command.strip().lower()
+        normalized_token = _normalize_token(normalized)
+        for record in reversed(runtime_records):
+            existing_token_tag = next(
+                (tag for tag in record.tags if tag.startswith("command_token:")),
+                None,
+            )
+            if existing_token_tag:
+                existing_token = existing_token_tag.split(":", 1)[1]
+                if existing_token == normalized_token:
+                    return True
+                continue
+            if "command=" in record.content:
+                existing = record.content.split("command=", 1)[1].split(";", 1)[0].strip().lower()
+                if existing == normalized:
+                    return True
+        return False
+
+    def _compose_transcript(
+        self,
+        player_command: str,
+        current_phase_id: str,
+        current_location_id: str,
+        write_intents: list[WriteIntent],
+        recap_trigger: bool,
+    ) -> str:
+        categories = ", ".join(intent.category for intent in write_intents)
+        recap_text = "Recap prepared from stored state." if recap_trigger else "Recap not requested."
+        return (
+            f"Processed command '{player_command.strip()}'. "
+            f"Phase={current_phase_id}; Location={current_location_id}. "
+            f"Write intents: {categories}. {recap_text}"
+        )
+
+    def _build_write_intents(
+        self,
+        *,
+        turn_input: TurnInput,
+        turn_index: int,
+        current_phase_id: str,
+        current_location_id: str,
+        runtime_records: list[MemoryRecord],
+    ) -> list[WriteIntent]:
+        categories = self._classify_categories(
+            player_command=turn_input.player_command,
+            recap_requested=turn_input.recap_requested,
+            runtime_records=runtime_records,
+        )
+        lineage_slug = _normalize_token(turn_input.lineage_id)
+        command_token = _normalize_token(turn_input.player_command)
+        intents = []
+        for category in categories:
+            record_id = f"runtime_{lineage_slug}_turn_{turn_index}_{category}"
+            tags = [
+                "topic:inheritance-manor",
+                "scope:project",
+                f"kind:{category}",
+                "layer:implementation",
+                f"phase:{current_phase_id}",
+                f"location:{current_location_id}",
+                f"campaign:{_normalize_token(self._project_id)}",
+                f"command_token:{command_token}",
+            ]
+            intents.append(
+                WriteIntent(
+                    category=category,
+                    record_id=record_id,
+                    district="practical_execution",
+                    content=f"lineage={turn_input.lineage_id}; command={turn_input.player_command.strip()}; category={category}",
+                    tags=tags,
+                )
+            )
+        return intents

--- a/src/yorkz/turn_orchestration.py
+++ b/src/yorkz/turn_orchestration.py
@@ -82,6 +82,11 @@ class TurnOrchestrator:
     """Framework-neutral turn orchestrator for the text-first runtime contract."""
 
     def __init__(self, *, memory_store: MemorySystem, project_id: str) -> None:
+        if memory_store.project_id != project_id:
+            raise ValueError(
+                "TurnOrchestrator memory_store.project_id "
+                f"'{memory_store.project_id}' does not match project_id '{project_id}'."
+            )
         self._memory_store = memory_store
         self._project_id = project_id
 

--- a/src/yorkz/turn_orchestration.py
+++ b/src/yorkz/turn_orchestration.py
@@ -37,6 +37,7 @@ class TurnInput:
     project_id: str
     lineage_id: str
     player_command: str
+    campaign_id: str | None = None
     phase_hint: str | None = None
     location_hint: str | None = None
     recap_requested: bool = False
@@ -164,33 +165,81 @@ class TurnOrchestrator:
         for record in reversed(runtime_records):
             phase_tag = next((tag for tag in record.tags if tag.startswith("phase:")), None)
             if phase_tag:
-                return phase_tag.split(":", 1)[1]
+                return self._normalize_phase_id(phase_tag.split(":", 1)[1])
         if phase_hint:
-            return phase_hint
+            return self._normalize_phase_id(phase_hint)
+        authored_phase_tags = sorted(
+            tag.split(":", 1)[1]
+            for record in self._memory_store.records.values()
+            if record.memory_type == "authored" and record.project_id == self._project_id
+            for tag in record.tags
+            if tag.startswith("phase:")
+        )
+        if authored_phase_tags:
+            return self._normalize_phase_id(authored_phase_tags[0])
         authored_phase_ids = sorted(
             record.record_id
             for record in self._memory_store.records.values()
             if record.memory_type == "authored" and record.record_id.startswith("phase_")
         )
         if authored_phase_ids:
-            return authored_phase_ids[0]
-        return "phase_unknown"
+            return self._normalize_phase_id(authored_phase_ids[0])
+        return "unknown"
 
     def _resolve_location_id(self, runtime_records: list[MemoryRecord], location_hint: str | None) -> str:
         for record in reversed(runtime_records):
             location_tag = next((tag for tag in record.tags if tag.startswith("location:")), None)
             if location_tag:
-                return location_tag.split(":", 1)[1]
+                return self._normalize_location_id(location_tag.split(":", 1)[1])
         if location_hint:
-            return location_hint
+            return self._normalize_location_id(location_hint)
+        authored_location_tags = sorted(
+            tag.split(":", 1)[1]
+            for record in self._memory_store.records.values()
+            if record.memory_type == "authored" and record.project_id == self._project_id
+            for tag in record.tags
+            if tag.startswith("location:")
+        )
+        if authored_location_tags:
+            return self._normalize_location_id(authored_location_tags[0])
         authored_location_ids = sorted(
             record.record_id
             for record in self._memory_store.records.values()
             if record.memory_type == "authored" and record.record_id.startswith("loc_")
         )
         if authored_location_ids:
-            return authored_location_ids[0]
-        return "location_unknown"
+            return self._normalize_location_id(authored_location_ids[0])
+        return "unknown"
+
+    def _normalize_phase_id(self, phase_id: str) -> str:
+        normalized = _normalize_token(phase_id)
+        if normalized.startswith("phase_"):
+            return normalized[len("phase_") :]
+        return normalized
+
+    def _normalize_location_id(self, location_id: str) -> str:
+        normalized = _normalize_token(location_id)
+        if normalized.startswith("loc_"):
+            normalized = normalized[len("loc_") :]
+        for suffix in ("_day", "_night"):
+            if normalized.endswith(suffix):
+                normalized = normalized[: -len(suffix)]
+                break
+        return normalized
+
+    def _resolve_campaign_id(self, turn_input: TurnInput) -> str | None:
+        if turn_input.campaign_id:
+            return _normalize_token(turn_input.campaign_id)
+        authored_campaign_tags = sorted(
+            tag.split(":", 1)[1]
+            for record in self._memory_store.records.values()
+            if record.memory_type == "authored" and record.project_id == self._project_id
+            for tag in record.tags
+            if tag.startswith("campaign:")
+        )
+        if authored_campaign_tags:
+            return _normalize_token(authored_campaign_tags[0])
+        return None
 
     def _resolve_recap_inputs(self, runtime_records: list[MemoryRecord], recap_requested: bool) -> list[str]:
         if not recap_requested:
@@ -291,6 +340,7 @@ class TurnOrchestrator:
         )
         lineage_slug = _normalize_token(turn_input.lineage_id)
         command_token = _normalize_token(turn_input.player_command)
+        campaign_id = self._resolve_campaign_id(turn_input)
         intents = []
         for category in categories:
             record_id = f"runtime_{lineage_slug}_turn_{turn_index}_{category}"
@@ -301,9 +351,10 @@ class TurnOrchestrator:
                 "layer:implementation",
                 f"phase:{current_phase_id}",
                 f"location:{current_location_id}",
-                f"campaign:{_normalize_token(self._project_id)}",
                 f"command_token:{command_token}",
             ]
+            if campaign_id:
+                tags.append(f"campaign:{campaign_id}")
             intents.append(
                 WriteIntent(
                     category=category,

--- a/tests/test_turn_orchestration.py
+++ b/tests/test_turn_orchestration.py
@@ -194,3 +194,56 @@ def test_classification_uses_whole_word_tokens() -> None:
     )
 
     assert [intent.category for intent in output.write_intents] == ["decision"]
+
+
+def test_write_intents_use_campaign_from_authored_tags_not_project_id() -> None:
+    store = _build_store()
+    orchestrator = TurnOrchestrator(memory_store=store, project_id="yorkz")
+
+    output = orchestrator.process_turn(
+        TurnInput(
+            session_id="s1",
+            project_id="yorkz",
+            lineage_id="lineage-a",
+            player_command="inspect desk",
+        )
+    )
+
+    assert any("campaign:inheritance_manor" in intent.tags for intent in output.write_intents)
+    assert all("campaign:yorkz" not in intent.tags for intent in output.write_intents)
+
+
+def test_phase_and_location_defaults_are_normalized() -> None:
+    store = _build_store()
+    orchestrator = TurnOrchestrator(memory_store=store, project_id="yorkz")
+
+    output = orchestrator.process_turn(
+        TurnInput(
+            session_id="s1",
+            project_id="yorkz",
+            lineage_id="lineage-a",
+            player_command="wait",
+        )
+    )
+
+    assert output.current_phase_id == "arrival"
+    assert output.current_location_id == "great_hall"
+    assert all("phase:phase_arrival" not in intent.tags for intent in output.write_intents)
+    assert all("location:loc_great_hall_day" not in intent.tags for intent in output.write_intents)
+
+
+def test_turn_input_campaign_id_overrides_authored_campaign_tag() -> None:
+    store = _build_store()
+    orchestrator = TurnOrchestrator(memory_store=store, project_id="yorkz")
+
+    output = orchestrator.process_turn(
+        TurnInput(
+            session_id="s1",
+            project_id="yorkz",
+            lineage_id="lineage-a",
+            player_command="inspect desk",
+            campaign_id="inheritance-manor-prologue-v1",
+        )
+    )
+
+    assert any("campaign:inheritance_manor_prologue_v1" in intent.tags for intent in output.write_intents)

--- a/tests/test_turn_orchestration.py
+++ b/tests/test_turn_orchestration.py
@@ -1,0 +1,196 @@
+from __future__ import annotations
+
+import pytest
+
+from yorkz.memory_system import MemoryRecord, MemorySystem, make_authored_id
+from yorkz.turn_orchestration import TurnInput, TurnOrchestrator
+
+
+def _tags(*extra: str) -> list[str]:
+    return [
+        "topic:inheritance-manor",
+        "scope:project",
+        "kind:reference",
+        "layer:architecture",
+        "campaign:inheritance_manor",
+        *extra,
+    ]
+
+
+def _build_store() -> MemorySystem:
+    store = MemorySystem(project_id="yorkz")
+    store.upsert(
+        MemoryRecord(
+            record_id=make_authored_id("phase", "arrival"),
+            content="Arrival phase anchor.",
+            district="logical_analysis",
+            tags=_tags("phase:arrival"),
+            project_id="yorkz",
+            memory_type="authored",
+        )
+    )
+    store.upsert(
+        MemoryRecord(
+            record_id=make_authored_id("loc", "great_hall", "day"),
+            content="Great Hall day anchor.",
+            district="logical_analysis",
+            tags=_tags("location:great_hall", "state:day"),
+            project_id="yorkz",
+            memory_type="authored",
+        )
+    )
+    return store
+
+
+def test_turn_contract_rejects_empty_lineage_id() -> None:
+    with pytest.raises(ValueError):
+        TurnInput(
+            session_id="s1",
+            project_id="yorkz",
+            lineage_id="",
+            player_command="inspect desk",
+        )
+
+
+def test_runtime_retrieval_is_lineage_scoped() -> None:
+    store = _build_store()
+    store.upsert(
+        MemoryRecord(
+            record_id="runtime_a_1",
+            content="lineage=lineage-a; command=inspect desk; category=clue",
+            district="practical_execution",
+            tags=_tags("kind:clue", "phase:arrival", "location:great_hall"),
+            project_id="yorkz",
+            memory_type="runtime",
+            lineage_id="lineage-a",
+        )
+    )
+    store.upsert(
+        MemoryRecord(
+            record_id="runtime_b_1",
+            content="lineage=lineage-b; command=inspect desk; category=clue",
+            district="practical_execution",
+            tags=_tags("kind:clue", "phase:arrival", "location:great_hall"),
+            project_id="yorkz",
+            memory_type="runtime",
+            lineage_id="lineage-b",
+        )
+    )
+
+    orchestrator = TurnOrchestrator(memory_store=store, project_id="yorkz")
+    output = orchestrator.process_turn(
+        TurnInput(
+            session_id="s1",
+            project_id="yorkz",
+            lineage_id="lineage-a",
+            player_command="inspect desk",
+        )
+    )
+
+    assert "runtime_a_1" in output.audit_trace["runtime_record_ids"]
+    assert "runtime_b_1" not in output.audit_trace["runtime_record_ids"]
+    assert output.audit_trace["lineage_id"] == "lineage-a"
+
+
+def test_orchestrator_rejects_turn_input_for_other_project() -> None:
+    store = _build_store()
+    orchestrator = TurnOrchestrator(memory_store=store, project_id="yorkz")
+
+    with pytest.raises(ValueError):
+        orchestrator.process_turn(
+            TurnInput(
+                session_id="s1",
+                project_id="not-yorkz",
+                lineage_id="lineage-a",
+                player_command="inspect desk",
+            )
+        )
+
+
+def test_write_intents_are_deterministic_for_same_state() -> None:
+    store = _build_store()
+    orchestrator = TurnOrchestrator(memory_store=store, project_id="yorkz")
+
+    turn_input = TurnInput(
+        session_id="s1",
+        project_id="yorkz",
+        lineage_id="lineage-a",
+        player_command="inspect desk",
+    )
+    first = orchestrator.process_turn(turn_input)
+    second = orchestrator.process_turn(turn_input)
+
+    assert [intent.record_id for intent in first.write_intents] == [
+        intent.record_id for intent in second.write_intents
+    ]
+    assert [intent.category for intent in first.write_intents] == [
+        intent.category for intent in second.write_intents
+    ]
+
+
+def test_recap_inputs_are_sourced_from_stored_runtime_state() -> None:
+    store = _build_store()
+    store.upsert(
+        MemoryRecord(
+            record_id="runtime_a_decision_1",
+            content="lineage=lineage-a; command=go library; category=decision",
+            district="practical_execution",
+            tags=_tags("kind:decision", "phase:arrival", "location:great_hall"),
+            project_id="yorkz",
+            memory_type="runtime",
+            lineage_id="lineage-a",
+        )
+    )
+    store.upsert(
+        MemoryRecord(
+            record_id="runtime_a_clue_1",
+            content="lineage=lineage-a; command=inspect portrait; category=clue",
+            district="practical_execution",
+            tags=_tags("kind:clue", "phase:arrival", "location:great_hall"),
+            project_id="yorkz",
+            memory_type="runtime",
+            lineage_id="lineage-a",
+        )
+    )
+    store.upsert(
+        MemoryRecord(
+            record_id="runtime_b_decision_1",
+            content="lineage=lineage-b; command=go outside; category=decision",
+            district="practical_execution",
+            tags=_tags("kind:decision", "phase:arrival", "location:exterior_front"),
+            project_id="yorkz",
+            memory_type="runtime",
+            lineage_id="lineage-b",
+        )
+    )
+
+    orchestrator = TurnOrchestrator(memory_store=store, project_id="yorkz")
+    output = orchestrator.process_turn(
+        TurnInput(
+            session_id="s1",
+            project_id="yorkz",
+            lineage_id="lineage-a",
+            player_command="recap",
+            recap_requested=True,
+        )
+    )
+
+    assert output.recap_trigger is True
+    assert set(output.recap_inputs) == {"runtime_a_decision_1", "runtime_a_clue_1"}
+    assert "runtime_b_decision_1" not in output.recap_inputs
+
+
+def test_classification_uses_whole_word_tokens() -> None:
+    store = _build_store()
+    orchestrator = TurnOrchestrator(memory_store=store, project_id="yorkz")
+
+    output = orchestrator.process_turn(
+        TurnInput(
+            session_id="s1",
+            project_id="yorkz",
+            lineage_id="lineage-a",
+            player_command="gorgeous weather",
+        )
+    )
+
+    assert [intent.category for intent in output.write_intents] == ["decision"]


### PR DESCRIPTION
## Summary
- implement framework-neutral turn contract and minimal AGM orchestration layer in src/yorkz/turn_orchestration.py
- enforce lineage-scoped runtime retrieval and explicit deterministic write intent categories (decision, clue, relationship_delta, phase_transition, recap, loop_telemetry)
- add focused architecture tests for contract validation, lineage scoping, deterministic write intents, recap inputs from stored state, and guard behavior
- update architecture plan doc with implementation-status linkage

## Validation
- pytest -q -> 30 passed

## Issue Linkage
Closes #11

## Notes
This PR keeps framework/client choice deferred while stabilizing a text-first contract layer for Milestone 3.